### PR TITLE
Add options for preprod Zulip

### DIFF
--- a/config/classes.py
+++ b/config/classes.py
@@ -44,6 +44,9 @@ class EnvVariables:
         self.vendor_to_otc_rst = os.getenv("VENDOR_TO_OTC_RST_URL")
         self.files_lines = os.getenv("FILES_LINES_URL")
         self.missing_child_prs = os.getenv("MISSING_CHILD_PRS_URL")
+        self.zulip_env = os.getenv("ZULIP_ENV")
+        self.zulip_preprod_stream = os.getenv("ZULIP_PREPROD_STREAM")
+        self.zulip_preprod_topic = os.getenv("ZULIP_PREPROD_TOPIC")
         self.check_env_variables()
 
     def check_env_variables(self):

--- a/scripts/eod_9_scheduler.py
+++ b/scripts/eod_9_scheduler.py
@@ -16,10 +16,6 @@ from config import Database, EnvVariables, Timer, setup_logging
 env_vars = EnvVariables()
 database = Database(env_vars)
 
-# Zulip stream and topic mapping for each squad, for different envs
-PREPROD_STREAM = os.getenv('ZULIP_PREPROD_STREAM', '4grafana')
-PREPROD_TOPIC = os.getenv('ZULIP_PREPROD_TOPIC', 'testing')
-
 PROD_STREAMS = {
     "Dashboard Squad": {"stream": "Dashboard Squad", "topic": "Orphaned PR's"},
     "Database Squad": {"stream": "Database Squad", "topic": "Doc alerts"},
@@ -34,13 +30,15 @@ PROD_STREAMS = {
     "eco": {"stream": "ecosystem", "topic": "Eyes-on-Docs alerts"}
 }
 
-if os.getenv('ZULIP_ENV') == 'preprod':
-    squad_streams = {
-        squad: {"stream": PREPROD_STREAM, "topic": PREPROD_TOPIC}
-        for squad in PROD_STREAMS
-    }
-else:
-    squad_streams = PROD_STREAMS
+def build_squad_streams(env):
+    if (env.zulip_env or "").strip().lower() == "preprod":
+        return {
+            squad: {"stream": env.zulip_preprod_stream, "topic": env.zulip_preprod_topic}
+            for squad in PROD_STREAMS
+        }
+    return PROD_STREAMS
+
+squad_streams = build_squad_streams(env_vars)
 
 # Rate limiting vars
 MESSAGE_LIMIT = 190

--- a/scripts/eod_9_scheduler.py
+++ b/scripts/eod_9_scheduler.py
@@ -3,7 +3,6 @@ This script sends Zulip messages to corresponding squads via Zulip bot, based on
 """
 
 import logging
-import os
 import time
 from datetime import datetime
 from urllib.parse import quote
@@ -30,6 +29,7 @@ PROD_STREAMS = {
     "eco": {"stream": "ecosystem", "topic": "Eyes-on-Docs alerts"}
 }
 
+
 def build_squad_streams(env):
     if (env.zulip_env or "").strip().lower() == "preprod":
         return {
@@ -38,7 +38,9 @@ def build_squad_streams(env):
         }
     return PROD_STREAMS
 
+
 squad_streams = build_squad_streams(env_vars)
+
 
 # Rate limiting vars
 MESSAGE_LIMIT = 190

--- a/scripts/eod_9_scheduler.py
+++ b/scripts/eod_9_scheduler.py
@@ -3,6 +3,7 @@ This script sends Zulip messages to corresponding squads via Zulip bot, based on
 """
 
 import logging
+import os
 import time
 from datetime import datetime
 from urllib.parse import quote
@@ -15,8 +16,11 @@ from config import Database, EnvVariables, Timer, setup_logging
 env_vars = EnvVariables()
 database = Database(env_vars)
 
-# Zulip stream and topic mapping for each squad
-squad_streams = {
+# Zulip stream and topic mapping for each squad, for different envs
+PREPROD_STREAM = os.getenv('ZULIP_PREPROD_STREAM', '4grafana')
+PREPROD_TOPIC = os.getenv('ZULIP_PREPROD_TOPIC', 'testing')
+
+PROD_STREAMS = {
     "Dashboard Squad": {"stream": "Dashboard Squad", "topic": "Orphaned PR's"},
     "Database Squad": {"stream": "Database Squad", "topic": "Doc alerts"},
     "Big Data and AI Squad": {"stream": "bigdata & ai", "topic": "helpcenter_alerts"},
@@ -29,6 +33,14 @@ squad_streams = {
     "Network Squad": {"stream": "network", "topic": "Alerts_HelpCenter"},
     "eco": {"stream": "ecosystem", "topic": "Eyes-on-Docs alerts"}
 }
+
+if os.getenv('ZULIP_ENV') == 'preprod':
+    squad_streams = {
+        squad: {"stream": PREPROD_STREAM, "topic": PREPROD_TOPIC}
+        for squad in PROD_STREAMS
+    }
+else:
+    squad_streams = PROD_STREAMS
 
 # Rate limiting vars
 MESSAGE_LIMIT = 190


### PR DESCRIPTION
1) Add option for routing alerts to testing Zulip stream and topic based on env (prod or preprod)